### PR TITLE
Batch norm

### DIFF
--- a/src/myrtlespeech/builders/deep_speech_2.py
+++ b/src/myrtlespeech/builders/deep_speech_2.py
@@ -99,8 +99,10 @@ def build(
               (rnn): LSTM(8, 32, bidirectional=True)
             )
           )
-          (fully_connected): FullyConnected(
-            (fully_connected): Linear(in_features=64, out_features=4, bias=True)
+          (fully_connected): Sequential(
+            (0): FullyConnected(
+              (fully_connected): Linear(in_features=64, out_features=4, bias=True)
+            )
           )
         )
     """

--- a/src/myrtlespeech/builders/deep_speech_2.py
+++ b/src/myrtlespeech/builders/deep_speech_2.py
@@ -94,8 +94,10 @@ def build(
             )
             (3): Conv1dTo2d(seq_len_support=True)
           )
-          (rnn): RNN(
-            (rnn): LSTM(8, 32, bidirectional=True)
+          (rnn): Sequential(
+            (0): RNN(
+              (rnn): LSTM(8, 32, bidirectional=True)
+            )
           )
           (fully_connected): FullyConnected(
             (fully_connected): Linear(in_features=64, out_features=4, bias=True)

--- a/src/myrtlespeech/builders/deep_speech_2.py
+++ b/src/myrtlespeech/builders/deep_speech_2.py
@@ -7,6 +7,7 @@ from myrtlespeech.builders.fully_connected import (
 )
 from myrtlespeech.builders.lookahead import build as build_lookahead
 from myrtlespeech.builders.rnn import build as build_rnn
+from myrtlespeech.model.cnn import BatchNorm
 from myrtlespeech.model.cnn import Conv1dTo2d
 from myrtlespeech.model.cnn import Conv2dTo1d
 from myrtlespeech.model.cnn import MaskConv1d
@@ -169,6 +170,14 @@ def _build_cnn(conv_blocks, input_features: int, input_channels: int):
                 )
             )
 
+            if conv_block.batch_norm:
+                layers.append(
+                    BatchNorm(
+                        batch_norm_type=torch.nn.BatchNorm1d,
+                        num_features=conv_cfg.output_channels,
+                    )
+                )
+
             input_channels = conv_cfg.output_channels
 
         elif convnd_str == "conv2d":
@@ -208,6 +217,14 @@ def _build_cnn(conv_blocks, input_features: int, input_channels: int):
                     bias=conv_cfg.bias,
                 )
             )
+
+            if conv_block.batch_norm:
+                layers.append(
+                    BatchNorm(
+                        batch_norm_type=torch.nn.BatchNorm2d,
+                        num_features=conv_cfg.output_channels,
+                    )
+                )
 
             input_channels = conv_cfg.output_channels
 

--- a/src/myrtlespeech/builders/fully_connected.py
+++ b/src/myrtlespeech/builders/fully_connected.py
@@ -53,18 +53,18 @@ def build(
         >>> build(cfg, input_features=32, output_features=16)
         Sequential(
           (0): FullyConnected(
-            (fully_connected): Linear(in_features=32, out_features=64,
-            bias=True)
+            (fully_connected): Linear(in_features=32, out_features=64, \
+bias=True)
             (activation): ReLU()
           )
           (1): FullyConnected(
-            (fully_connected): Linear(in_features=64, out_features=64,
-            bias=True)
+            (fully_connected): Linear(in_features=64, out_features=64, \
+bias=True)
             (activation): ReLU()
           )
           (2): FullyConnected(
-            (fully_connected): Linear(in_features=64, out_features=16,
-            bias=True)
+            (fully_connected): Linear(in_features=64, out_features=16, \
+bias=True)
           )
         )
     """

--- a/src/myrtlespeech/builders/fully_connected.py
+++ b/src/myrtlespeech/builders/fully_connected.py
@@ -8,8 +8,11 @@ def build(
     fully_connected_cfg: fully_connected_pb2.FullyConnected,
     input_features: int,
     output_features: int,
-) -> FullyConnected:
-    """Returns a :py:class:`.FullyConnected` based on the config.
+) -> torch.nn.Module:
+    """Returns a sequence of :py:class:`.FullyConnected` layers based on the
+    config, grouped in a :py:class:`torch.nn.Sequential` module.
+    All parameters and buffers are moved to the GPU with
+    :py:meth:`torch.nn.Module.cuda` if :py:func:`torch.cuda.is_available`.
 
     Args:
         fully_connected_cfg: A ``FullyConnected`` protobuf object containing
@@ -21,6 +24,18 @@ def build(
 
     Returns:
         A :py:class:`torch.nn.Module` based on the config.
+
+    Raises:
+        :py:class:`ValueError`: If ``num_hidden_layers < 0``.
+
+        :py:class:`ValueError`: If ``num_hidden_layers == 0 and
+        hidden_size > 0.
+
+        :py:class:`ValueError`: If ``num_hidden_layers == 0 and
+        hidden_activation_fn is not None``.
+
+        :py:class:`ValueError`: If ``num_hidden_layers > 0 and
+        hidden_size <= 0.
 
     Example:
         >>> from google.protobuf import text_format
@@ -36,13 +51,20 @@ def build(
         ...     fully_connected_pb2.FullyConnected()
         ... )
         >>> build(cfg, input_features=32, output_features=16)
-        FullyConnected(
-          (fully_connected): Sequential(
-            (0): Linear(in_features=32, out_features=64, bias=True)
-            (1): ReLU()
-            (2): Linear(in_features=64, out_features=64, bias=True)
-            (3): ReLU()
-            (4): Linear(in_features=64, out_features=16, bias=True)
+        Sequential(
+          (0): FullyConnected(
+            (fully_connected): Linear(in_features=32, out_features=64,
+            bias=True)
+            (activation): ReLU()
+          )
+          (1): FullyConnected(
+            (fully_connected): Linear(in_features=64, out_features=64,
+            bias=True)
+            (activation): ReLU()
+          )
+          (2): FullyConnected(
+            (fully_connected): Linear(in_features=64, out_features=16,
+            bias=True)
           )
         )
     """
@@ -50,14 +72,49 @@ def build(
     if isinstance(activation, torch.nn.Identity):
         activation = None
 
-    hidden_size = None
-    if fully_connected_cfg.hidden_size > 0:
-        hidden_size = fully_connected_cfg.hidden_size
+    num_hidden_layers = fully_connected_cfg.num_hidden_layers
+    hidden_size = fully_connected_cfg.hidden_size
 
-    return FullyConnected(
-        in_features=input_features,
-        out_features=output_features,
-        num_hidden_layers=fully_connected_cfg.num_hidden_layers,
-        hidden_size=hidden_size,
-        hidden_activation_fn=activation,
-    )
+    if num_hidden_layers < 0:
+        raise ValueError("num_hidden_layers must be >= 0")
+    elif num_hidden_layers == 0:
+        if hidden_size > 0:
+            raise ValueError("num_hidden_layers==0 but hidden_size > 0")
+        if activation is not None:
+            raise ValueError(
+                "num_hidden_layers==0 but hidden_activation_fn is not None"
+            )
+    else:
+        if hidden_size <= 0:
+            raise ValueError(
+                "hidden_size must be > 0 when num_hidden_layers > 0"
+            )
+
+    hidden_layers = []
+    for i in range(num_hidden_layers + 1):
+        # Hidden activation is eventually added only to the hidden layers
+        # before the last FullyConnected layer. The same is for the batch norm
+        # layers.
+        hidden_layers.append(
+            FullyConnected(
+                in_features=input_features if i == 0 else hidden_size,
+                out_features=hidden_size
+                if i < num_hidden_layers
+                else output_features,
+                hidden_activation_fn=activation
+                if i < num_hidden_layers
+                else None,
+                batch_norm=fully_connected_cfg.batch_norm
+                if i < num_hidden_layers
+                else False,
+            )
+        )
+        if i < num_hidden_layers:
+            assert hidden_size is not None
+
+    module = torch.nn.Sequential(*hidden_layers)
+
+    if torch.cuda.is_available():
+        module = module.cuda()
+
+    return module

--- a/src/myrtlespeech/builders/speech_to_text.py
+++ b/src/myrtlespeech/builders/speech_to_text.py
@@ -140,11 +140,13 @@ def build(stt_cfg: speech_to_text_pb2.SpeechToText) -> SpeechToText:
                 (rnn): LSTM(2048, 1024, bidirectional=True)
               )
             )
-            (fully_connected): FullyConnected(
-              (fully_connected): Sequential(
-                (0): Linear(in_features=2048, out_features=1024, bias=True)
-                (1): Hardtanh(min_val=0.0, max_val=20.0)
-                (2): Linear(in_features=1024, out_features=5, bias=True)
+            (fully_connected): Sequential(
+              (0): FullyConnected(
+                (fully_connected): Linear(in_features=2048, out_features=1024, bias=True)
+                (activation): Hardtanh(min_val=0.0, max_val=20.0)
+              )
+              (1): FullyConnected(
+                (fully_connected): Linear(in_features=1024, out_features=5, bias=True)
               )
             )
           )

--- a/src/myrtlespeech/builders/speech_to_text.py
+++ b/src/myrtlespeech/builders/speech_to_text.py
@@ -129,8 +129,16 @@ def build(stt_cfg: speech_to_text_pb2.SpeechToText) -> SpeechToText:
               )
               (3): Conv1dTo2d(seq_len_support=True)
             )
-            (rnn): RNN(
-              (rnn): LSTM(4, 1024, num_layers=3, bidirectional=True)
+            (rnn): Sequential(
+              (0): RNN(
+                (rnn): LSTM(4, 1024, bidirectional=True)
+              )
+              (1): RNN(
+                (rnn): LSTM(2048, 1024, bidirectional=True)
+              )
+              (2): RNN(
+                (rnn): LSTM(2048, 1024, bidirectional=True)
+              )
             )
             (fully_connected): FullyConnected(
               (fully_connected): Sequential(

--- a/src/myrtlespeech/configs/deep_speech_2_en.config
+++ b/src/myrtlespeech/configs/deep_speech_2_en.config
@@ -59,6 +59,7 @@ speech_to_text {
       num_layers: 3;
       bias: true;
       bidirectional: false;
+      batch_norm: true;
     }
 
     lookahead_block {

--- a/src/myrtlespeech/configs/deep_speech_2_en.config
+++ b/src/myrtlespeech/configs/deep_speech_2_en.config
@@ -80,6 +80,7 @@ speech_to_text {
           max_val: 20.0;
         }
       }
+      batch_norm: true;
     }
   }
 

--- a/src/myrtlespeech/configs/deep_speech_2_en.config
+++ b/src/myrtlespeech/configs/deep_speech_2_en.config
@@ -27,6 +27,7 @@ speech_to_text {
         padding_mode: SAME;
         bias: true;
       }
+      batch_norm: true;
       activation {
         hardtanh {
           min_val: 0.0;
@@ -45,6 +46,7 @@ speech_to_text {
         padding_mode: SAME;
         bias: true;
       }
+      batch_norm: true;
       activation {
         hardtanh {
           min_val: 0.0;

--- a/src/myrtlespeech/model/cnn.py
+++ b/src/myrtlespeech/model/cnn.py
@@ -489,6 +489,78 @@ class MaskConv2d(torch.nn.Conv2d):
 SeqLenT = TypeVar("SeqLenT", torch.Tensor, Tuple[torch.Tensor, torch.Tensor])
 
 
+class BatchNorm(torch.nn.Module):
+    r"""Applies batch norm to an input signal with a given length.
+
+    All parameters and buffers are moved to the GPU with
+    :py:meth:`torch.nn.Module.cuda` if :py:func:`torch.cuda.is_available`.
+
+    Args:
+        batch_norm_type: the type of batch norm to use. It can be
+        :py:class:`torch.BatchNorm1d`, :py:class:`torch.BatchNorm2d` or
+        :py:class:`torch.BatchNorm3d`.
+
+        num_features: input feature size.
+
+    Attributes:
+        batch_norm: An instance of :py:class:`torch.BatchNorm1d`,
+        :py:class:`torch.BatchNorm2d` or :py:class:`torch.BatchNorm3d`.
+
+    Raises:
+        :py:class:`ValueError`: If the batch_norm_type doesn't correspond to
+        one of :py:class:`torch.BatchNorm1d`, :py:class:`torch.BatchNorm2d` or
+        :py:class:`torch.BatchNorm3d`.
+
+    """
+
+    def __init__(self, batch_norm_type: torch.nn.Module, num_features: int):
+        super().__init__()
+
+        if batch_norm_type not in [
+            torch.nn.BatchNorm1d,
+            torch.nn.BatchNorm2d,
+            torch.nn.BatchNorm3d,
+        ]:
+            raise ValueError(f"Invalid batch norm type {batch_norm_type}")
+
+        self.batch_norm = batch_norm_type(num_features)
+        self.use_cuda = torch.cuda.is_available()
+        if self.use_cuda:
+            self.batch_norm = self.batch_norm.cuda()
+
+    def forward(
+        self, x: Tuple[torch.Tensor, torch.Tensor]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        r"""Returns the result of applying the rnn layer to ``x[0]``.
+
+        All inputs are moved to the GPU with :py:meth:`torch.nn.Module.cuda` if
+        :py:func:`torch.cuda.is_available` was :py:data:`True` on
+        initialisation.
+
+        Args
+            x: A tuple where the first element is the network input (a
+                :py:class:`torch.Tensor`) and the second element is
+                :py:class:`torch.Tensor` of size ``[batch]`` where each entry
+                represents the sequence length of the corresponding *input*
+                sequence.
+
+        Returns:
+            The first element of the Tuple return value is the result after
+            applying the module to ``x[0]``.
+
+            The second element of the Tuple return value is a
+            :py:class:`torch.Tensor` with size ``[batch]`` where each entry
+            represents the sequence length of the corresponding *output*
+            sequence.
+        """
+        if self.use_cuda:
+            x = (x[0].cuda(), x[1].cuda())
+
+        x_norm = self.batch_norm(x[0])
+
+        return x_norm, x[1]
+
+
 class Conv2dTo1d(torch.nn.Module):
     """Collapses input channel and feature dimensions for a 1d convolution."""
 

--- a/src/myrtlespeech/model/deep_speech_1.py
+++ b/src/myrtlespeech/model/deep_speech_1.py
@@ -86,7 +86,6 @@ class DeepSpeech1(torch.nn.Module):
             rnn_type=RNNType.LSTM,
             input_size=2 * n_hidden,
             hidden_size=n_hidden,
-            num_layers=1,
             bias=True,
             bidirectional=True,
             forget_gate_bias=forget_gate_bias,

--- a/src/myrtlespeech/model/fully_connected.py
+++ b/src/myrtlespeech/model/fully_connected.py
@@ -1,6 +1,5 @@
 from typing import Optional
 from typing import Tuple
-from typing import Union
 
 import torch
 
@@ -8,102 +7,50 @@ import torch
 class FullyConnected(torch.nn.Module):
     r"""A fully connected neural network.
 
-    All parameters and buffers are moved to the GPU with
-    :py:meth:`torch.nn.Module.cuda` if :py:func:`torch.cuda.is_available`.
-
     Args:
         in_features: Size of each input sample.
 
         out_features: Size of each output sample.
 
-        num_hidden_layers: Number of hidden layers. Must be a non-negative
-            integer. ``0`` means no hidden layers making this module the same
-            as a single :py:class:`torch.nn.Linear` layer.
-
-        hidden_size: The number of features output by each hidden layer, if
-            any.
-
         hidden_activation_fn: The activation function applied after each hidden
             layer, if any.
 
+        batch_norm: If :py:data:`True`, then batch normalization is added.
+
     Attributes:
-        fully_connected: A :py:class:`torch.nn.Module` that implements the
-            network specified by the class arguments. It is be an instance of
-            :py:class:`torch.nn.Linear` if ``num_hidden_layers == 0`` otherwise
-            it is an instance of :py:class:`torch.nn.Sequential`.
+        batch_norm: A :py:class:`torch.BatchNorm1d` instance.
+
+        fully_connected (:py:class:`torch.nn.Linear`):
+            A :py:class:`torch.nn.Module` that implements the fully connected
+            layer specified by the class arguments. It is an instance of
+            :py:class:`torch.nn.Linear`.
+
+        activation: the activation function applied after the linear layer, if
+        any.
 
         in_features: See Args.
 
         out_features: See Args.
-
-    Raises:
-        :py:class:`ValueError`: If ``num_hidden_layers < 0``.
-
-        :py:class:`ValueError`: If ``num_hidden_layers == 0 and hidden_size is
-            not None``.
-
-        :py:class:`ValueError`: If ``num_hidden_layers == 0 and
-        hidden_activation_fn is not None``.
     """
 
     def __init__(
         self,
         in_features: int,
         out_features: int,
-        num_hidden_layers: int,
-        hidden_size: Optional[int],
         hidden_activation_fn: Optional[torch.nn.Module],
+        batch_norm: bool = False,
     ):
-        if num_hidden_layers < 0:
-            raise ValueError("num_hidden_layers must be >= 0")
-
-        if num_hidden_layers == 0:
-            if hidden_size is not None:
-                raise ValueError(
-                    "num_hidden_layers==0 but hidden_size is not None"
-                )
-            if hidden_activation_fn is not None:
-                raise ValueError(
-                    "num_hidden_layers==0 but hidden_activation_fn is not None"
-                )
-
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
-        self.fully_connected = self._build_fully_connected(
-            in_features,
-            out_features,
-            num_hidden_layers,
-            hidden_size,
-            hidden_activation_fn,
+
+        self.fully_connected = torch.nn.Linear(in_features, out_features)
+        self.batch_norm = (
+            torch.nn.BatchNorm1d(out_features) if batch_norm else None
         )
+        self.activation = hidden_activation_fn
 
         self.use_cuda = torch.cuda.is_available()
-        if self.use_cuda:
-            self.fully_connected = self.fully_connected.cuda()
-
-    def _build_fully_connected(
-        self,
-        in_features: int,
-        out_features: int,
-        num_hidden_layers: int,
-        hidden_size: Optional[int],
-        hidden_activation_fn: Optional[torch.nn.Module],
-    ) -> Union[torch.nn.Linear, torch.nn.Sequential]:
-        hidden_layers = []
-        for _ in range(num_hidden_layers):
-            hidden_layers.append(torch.nn.Linear(in_features, hidden_size))
-            if hidden_activation_fn:
-                hidden_layers.append(hidden_activation_fn)
-            assert hidden_size is not None
-            in_features = hidden_size
-
-        module = torch.nn.Linear(in_features, out_features)
-
-        if hidden_layers:
-            module = torch.nn.Sequential(*hidden_layers, module)
-
-        return module
 
     def forward(
         self, x: Tuple[torch.Tensor, torch.Tensor]
@@ -134,4 +81,15 @@ class FullyConnected(torch.nn.Module):
             x = (x[0].cuda(), x[1].cuda())
 
         result = self.fully_connected(x[0])
+
+        if self.batch_norm is not None:
+            # Collapses input of dim T*N*H to (T*N)*H and gives it to a batch
+            # norm layer.
+            # Allows handling of variable sequence lengths and minibatch sizes.
+            t, n = result.size(0), result.size(1)
+            x_norm = self.batch_norm(result.reshape(t * n, -1))
+            result = x_norm.reshape(t, n, -1)
+
+        if self.activation is not None:
+            result = self.activation(result)
         return result, x[1]

--- a/src/myrtlespeech/model/rnn.py
+++ b/src/myrtlespeech/model/rnn.py
@@ -12,15 +12,16 @@ class RNNType(IntEnum):
 
 
 class RNN(torch.nn.Module):
-    """A recurrent neural network.
+    """A layer in a recurrent neural network.
 
     See :py:class:`torch.nn.LSTM`, :py:class:`torch.nn.GRU` and
     :py:class:`torch.nn.RNN` for more information as these are used internally
     (see Attributes).
 
     This wrapper ensures the sequence length information is correctly used by
-    the RNN (i.e. using :py:func:`torch.nn.utils.rnn.pad_packed_sequence` and
-    :py:func:`torch.nn.utils.rnn.pad_packed_sequence`).
+    the RNN layer (i.e. using :py:func:`torch.nn.utils.rnn.pad_packed_sequence`
+    and :py:func:`torch.nn.utils.rnn.pad_packed_sequence`).
+    Moreover it handles batch normalization in the recurrent layer.
 
     Args:
         rnn_type: The type of recurrent neural network cell to use. See
@@ -30,10 +31,11 @@ class RNN(torch.nn.Module):
 
         hidden_size: The number of features in the hidden state.
 
-        num_layers: The number of recurrent layers.
-
         bias: If :py:data:`False`, then the layer does not use the bias weights
             ``b_ih`` and ``b_hh``.
+
+        batch_first: If :py:data:`True`, then the input and output tensors are
+            provided as ``[batch, seq_len, in_features]``.
 
         dropout: If non-zero, introduces a dropout layer on the
             outputs of each LSTM layer except the last layer,
@@ -49,10 +51,11 @@ class RNN(torch.nn.Module):
             See `Jozefowicz et al., 2015
             <http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf>`_.
 
-        batch_first: If :py:data:`True`, then the input and output tensors are
-            provided as ``[batch, seq_len, in_features]``.
+        batch_norm: If :py:data:`True`, then batch normalization is added.
 
     Attributes:
+        batch_norm: A :py:class:`torch.BatchNorm1d` instance.
+
         rnn: A :py:class:`torch.LSTM`, :py:class:`torch.GRU`, or
             :py:class:`torch.RNN` instance.
     """
@@ -62,12 +65,12 @@ class RNN(torch.nn.Module):
         rnn_type: RNNType,
         input_size: int,
         hidden_size: int,
-        num_layers: int = 1,
         bias: int = True,
+        batch_first: bool = False,
         dropout: float = 0.0,
         bidirectional: bool = False,
         forget_gate_bias: Optional[float] = None,
-        batch_first: bool = False,
+        batch_norm: bool = False,
     ):
         super().__init__()
         if rnn_type == RNNType.LSTM:
@@ -80,11 +83,13 @@ class RNN(torch.nn.Module):
             raise ValueError(f"unknown rnn_type {rnn_type}")
 
         self.batch_first = batch_first
+        self.batch_norm = (
+            torch.nn.BatchNorm1d(input_size) if batch_norm else None
+        )
 
         self.rnn = rnn_cls(
             input_size=input_size,
             hidden_size=hidden_size,
-            num_layers=num_layers,
             bias=bias,
             batch_first=self.batch_first,
             dropout=dropout,
@@ -92,20 +97,20 @@ class RNN(torch.nn.Module):
         )
 
         if rnn_type == RNNType.LSTM and bias and forget_gate_bias is not None:
-            for l in range(num_layers):
-                ih = getattr(self.rnn, f"bias_ih_l{l}")
-                ih.data[hidden_size : 2 * hidden_size] = forget_gate_bias
-                hh = getattr(self.rnn, f"bias_hh_l{l}")
-                hh.data[hidden_size : 2 * hidden_size] = 0.0
+            ih = getattr(self.rnn, f"bias_ih_l0")
+            ih.data[hidden_size : 2 * hidden_size] = forget_gate_bias
+            hh = getattr(self.rnn, f"bias_hh_l0")
+            hh.data[hidden_size : 2 * hidden_size] = 0.0
 
         self.use_cuda = torch.cuda.is_available()
         if self.use_cuda:
+            self.batch_norm = self.batch_norm.cuda() if batch_norm else None
             self.rnn = self.rnn.cuda()
 
     def forward(
         self, x: Tuple[torch.Tensor, torch.Tensor]
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        r"""Returns the result of applying the rnn to ``x[0]``.
+        r"""Returns the result of applying the rnn layer to ``x[0]``.
 
         All inputs are moved to the GPU with :py:meth:`torch.nn.Module.cuda` if
         :py:func:`torch.cuda.is_available` was :py:data:`True` on
@@ -122,7 +127,7 @@ class RNN(torch.nn.Module):
 
         Returns:
             The first element of the Tuple return value is the result after
-            applying the RNN to ``x[0]``. It must have size ``[seq_len,
+            applying the RNN layer to ``x[0]``. It must have size ``[seq_len,
             batch, out_features]`` or ``[batch, seq_len, out_features]`` if
             ``batch_first=True``.
 
@@ -134,6 +139,14 @@ class RNN(torch.nn.Module):
         """
         if self.use_cuda:
             x = (x[0].cuda(), x[1].cuda())
+
+        if self.batch_norm is not None:
+            # Collapses input of dim T*N*H to (T*N)*H and gives it to a batch
+            # norm layer.
+            # Allows handling of variable sequence lengths and minibatch sizes.
+            t, n = x[0].size(0), x[0].size(1)
+            x_norm = self.batch_norm(x[0].view(t * n, -1))
+            x = (x_norm.view(t, n, -1), x[1])
 
         # Record sequence length to enable DataParallel
         # https://pytorch.org/docs/stable/notes/faq.html#pack-rnn-unpack-with-data-parallelism

--- a/src/myrtlespeech/protos/deep_speech_2.proto
+++ b/src/myrtlespeech/protos/deep_speech_2.proto
@@ -19,7 +19,11 @@ message DeepSpeech2 {
       Conv1d conv1d = 1;
       Conv2d conv2d = 2;
     }
-    Activation activation = 3;
+
+    // If true then batch normalization is added after the conv layer.
+    bool batch_norm = 3;
+
+    Activation activation = 4;
   }
 
   // If no_lookahead, activation is ignored.

--- a/src/myrtlespeech/protos/fully_connected.proto
+++ b/src/myrtlespeech/protos/fully_connected.proto
@@ -21,4 +21,7 @@ message FullyConnected {
   // ``activation_fn`` has no meaning when ``num_hidden_layers: 0`` as there is
   // only an output layer and no hidden layers!
   Activation activation = 3;
+
+  // If true then batch normalization is added to all fully connected layers.
+  bool batch_norm = 4;
 }

--- a/src/myrtlespeech/protos/rnn.proto
+++ b/src/myrtlespeech/protos/rnn.proto
@@ -31,4 +31,7 @@ message RNN {
   // When using an LSTM and bias is True then, if set, the total forget gate
   // bias will be initialised to this value.
   google.protobuf.FloatValue forget_gate_bias = 6;
+
+  // If true then batch normalization is added to the rnn.
+  bool batch_norm = 7;
 }

--- a/tests/builders/test_fully_connected.py
+++ b/tests/builders/test_fully_connected.py
@@ -1,4 +1,8 @@
+from typing import Dict
+from typing import Tuple
+
 import hypothesis.strategies as st
+import pytest
 import torch
 from hypothesis import assume
 from hypothesis import given
@@ -8,6 +12,7 @@ from myrtlespeech.protos import fully_connected_pb2
 
 from tests.builders.test_activation import activation_match_cfg
 from tests.protos.test_fully_connected import fully_connecteds
+from tests.utils.utils import tensors
 
 
 # Utilities -------------------------------------------------------------------
@@ -20,45 +25,34 @@ def fully_connected_module_match_cfg(
     output_features: int,
 ) -> None:
     """Ensures ``FullyConnected`` module matches protobuf configuration."""
-    fully_connected = fully_connected.fully_connected  # get torch module
-
-    # if no hidden layers then test that the module is Linear with corret
-    # sizes, ignore activation
-    if fully_connected_cfg.num_hidden_layers == 0:
-        assert isinstance(fully_connected, torch.nn.Linear)
-        assert fully_connected.in_features == input_features
-        assert fully_connected.out_features == output_features
-        return
-
     # otherwise it will be a Sequential of layers
     assert isinstance(fully_connected, torch.nn.Sequential)
 
     # configuration of each layer in Sequential depends on whether activation
-    # is present
+    # and batch norm are present
     act_fn_is_none = fully_connected_cfg.activation.HasField("identity")
+    batch_norm = fully_connected_cfg.batch_norm
+    hidden_size = fully_connected_cfg.hidden_size
 
-    if act_fn_is_none:
-        assert (
-            len(fully_connected) == fully_connected_cfg.num_hidden_layers + 1
-        )
-    else:
-        assert (
-            len(fully_connected)
-            == 2 * fully_connected_cfg.num_hidden_layers + 1
-        )
+    assert len(fully_connected) == fully_connected_cfg.num_hidden_layers + 1
 
     for idx, module in enumerate(fully_connected):
         # should be alternating linear/activation_fn layers if !act_fn_is_none
-        if act_fn_is_none or ((not act_fn_is_none) and idx % 2 == 0):
-            assert isinstance(module, torch.nn.Linear)
-            assert module.in_features == input_features
-            if idx == len(fully_connected) - 1:
-                assert module.out_features == output_features
-            else:
-                assert module.out_features == fully_connected_cfg.hidden_size
-            input_features = fully_connected_cfg.hidden_size
-        elif not act_fn_is_none:
-            activation_match_cfg(module, fully_connected_cfg.activation)
+        # or linear/batch_norm_activation_fn if also batch_norm is True
+        assert isinstance(module.fully_connected, torch.nn.Linear)
+        assert module.fully_connected.in_features == input_features
+        if idx == len(fully_connected) - 1:
+            assert module.fully_connected.out_features == output_features
+        else:
+            assert module.fully_connected.out_features == hidden_size
+        input_features = hidden_size
+
+        if batch_norm and idx < fully_connected_cfg.num_hidden_layers:
+            assert isinstance(module.batch_norm, torch.nn.BatchNorm1d)
+        if not act_fn_is_none and idx < fully_connected_cfg.num_hidden_layers:
+            activation_match_cfg(
+                module.activation, fully_connected_cfg.activation
+            )
 
 
 # Tests -----------------------------------------------------------------------
@@ -77,9 +71,169 @@ def test_build_fully_connected_returns_correct_module_structure(
     """Ensures Module returned has correct structure."""
     if fully_connected_cfg.num_hidden_layers == 0:
         assume(fully_connected_cfg.hidden_size is None)
+        assume(fully_connected_cfg.batch_norm is None)
         assume(fully_connected_cfg.activation is None)
 
     actual = build(fully_connected_cfg, input_features, output_features)
     fully_connected_module_match_cfg(
         actual, fully_connected_cfg, input_features, output_features
     )
+
+
+@given(
+    fully_connected_kwargs=fully_connecteds(return_kwargs=True),
+    input_features=st.integers(min_value=1, max_value=32),
+    output_features=st.integers(min_value=1, max_value=32),
+    num_hidden_layers=st.integers(-1000, -1),
+)
+def test_fully_connected_raises_value_error_negative_num_hidden_layers(
+    fully_connected_kwargs: Tuple[FullyConnected, Dict],
+    input_features: int,
+    output_features: int,
+    num_hidden_layers: int,
+) -> None:
+    """Ensures ValueError raised when num_hidden_layers < 0."""
+    _, kwargs = fully_connected_kwargs
+    kwargs["num_hidden_layers"] = num_hidden_layers
+    with pytest.raises(ValueError):
+        build(
+            fully_connected_pb2.FullyConnected(**kwargs),
+            input_features,
+            output_features,
+        )
+
+
+@given(
+    fully_connected_kwargs=fully_connecteds(return_kwargs=True),
+    input_features=st.integers(min_value=1, max_value=32),
+    output_features=st.integers(min_value=1, max_value=32),
+    hidden_size=st.integers(1, 1000),
+)
+def test_fully_connected_raises_value_error_hidden_size_not_none(
+    fully_connected_kwargs: Tuple[FullyConnected, Dict],
+    input_features: int,
+    output_features: int,
+    hidden_size: int,
+) -> None:
+    """Ensures ValueError raised when no hidden layers and not hidden_size."""
+    _, kwargs = fully_connected_kwargs
+    kwargs["num_hidden_layers"] = 0
+    kwargs["hidden_size"] = hidden_size
+    with pytest.raises(ValueError):
+        build(
+            fully_connected_pb2.FullyConnected(**kwargs),
+            input_features,
+            output_features,
+        )
+
+
+@given(
+    fully_connected_kwargs=fully_connecteds(return_kwargs=True),
+    input_features=st.integers(min_value=1, max_value=32),
+    output_features=st.integers(min_value=1, max_value=32),
+    hidden_activation_fn=st.sampled_from(
+        [torch.nn.ReLU(), torch.nn.Hardtanh(min_val=0.0, max_val=20.0)]
+    ),
+)
+def test_fully_connected_raises_value_error_hidden_activation_fn_not_none(
+    fully_connected_kwargs: Tuple[FullyConnected, Dict],
+    input_features: int,
+    output_features: int,
+    hidden_activation_fn: torch.nn.Module,
+) -> None:
+    """Ensures ValueError raised when no hidden layers and no act fn."""
+    _, kwargs = fully_connected_kwargs
+    kwargs["num_hidden_layers"] = 0
+    kwargs["hidden_activation_fn"] = hidden_activation_fn
+    with pytest.raises(ValueError):
+        build(
+            fully_connected_pb2.FullyConnected(**kwargs),
+            input_features,
+            output_features,
+        )
+
+
+@given(
+    fully_connected_kwargs=fully_connecteds(
+        return_kwargs=True, valid_only=True
+    ),
+    output_features=st.integers(min_value=1, max_value=32),
+    tensor=tensors(min_n_dims=3, max_n_dims=3),
+)
+def test_fully_connected_forward_returns_correct_size(
+    fully_connected_kwargs: Tuple[FullyConnected, Dict],
+    output_features: int,
+    tensor: torch.Tensor,
+) -> None:
+    # create new FullyConnected that accepts in_features sized input
+    _, kwargs = fully_connected_kwargs
+    # if batch_size == 1 don't add batch norm to the fully connected network
+    if tensor.size(1) == 1:
+        kwargs["batch_norm"] = False
+
+    fully_connected = build(
+        fully_connected_pb2.FullyConnected(**kwargs),
+        tensor.size()[-1],
+        output_features,
+    )
+
+    max_seq_len, batch_size, *_ = tensor.size()
+    in_seq_lens = torch.randint(
+        low=1,
+        high=max_seq_len + 1,
+        size=[batch_size],
+        dtype=torch.int32,
+        requires_grad=False,
+    )
+    out, _ = fully_connected((tensor, in_seq_lens))
+
+    in_size = tensor.size()
+    out_size = out.size()
+
+    assert len(in_size) == len(out_size)
+    assert in_size[:-1] == out_size[:-1]
+    assert out_size[-1] == output_features
+
+
+@given(
+    fully_connected_kwargs=fully_connecteds(
+        return_kwargs=True, valid_only=True
+    ),
+    in_features=st.integers(min_value=1, max_value=32),
+    out_features=st.integers(min_value=1, max_value=32),
+    batch_size=st.integers(min_value=1, max_value=16),
+    max_seq_len=st.integers(min_value=1, max_value=64),
+)
+def test_fully_connected_module_returns_correct_seq_lens(
+    fully_connected_kwargs: Tuple[FullyConnected, Dict],
+    in_features: int,
+    out_features: int,
+    batch_size: int,
+    max_seq_len: int,
+):
+    """Ensures FullyConnected returns correct seq_lens when support enabled."""
+    # create new FullyConnected that accepts in_features sized input
+    _, kwargs = fully_connected_kwargs
+    # if batch_size == 1 don't add batch norm to the fully connected network
+    kwargs["batch_norm"] = batch_size > 1
+
+    fully_connected = build(
+        fully_connected_pb2.FullyConnected(**kwargs), in_features, out_features
+    )
+
+    tensor = torch.empty(
+        [max_seq_len, batch_size, fully_connected[0].in_features],
+        requires_grad=False,
+    ).normal_()
+
+    in_seq_lens = torch.randint(
+        low=1,
+        high=max_seq_len + 1,
+        size=[batch_size],
+        dtype=torch.int32,
+        requires_grad=False,
+    )
+
+    _, act_seq_lens = fully_connected((tensor, in_seq_lens))
+
+    assert torch.all(act_seq_lens == in_seq_lens)

--- a/tests/model/test_fully_connected.py
+++ b/tests/model/test_fully_connected.py
@@ -3,12 +3,9 @@ from typing import Tuple
 from typing import Union
 
 import hypothesis.strategies as st
-import pytest
 import torch
 from hypothesis import given
 from myrtlespeech.model.fully_connected import FullyConnected
-
-from tests.utils.utils import tensors
 
 
 # Fixtures and Strategies -----------------------------------------------------
@@ -31,12 +28,41 @@ def fully_connecteds(
         kwargs["hidden_activation_fn"] = None
     else:
         kwargs["hidden_size"] = draw(st.integers(1, 32))
+        kwargs["batch_norm"] = draw(st.booleans())
         kwargs["hidden_activation_fn"] = draw(
-            st.sampled_from([torch.nn.ReLU(), torch.nn.Tanh()])
+            st.sampled_from(
+                [torch.nn.ReLU(), torch.nn.Hardtanh(min_val=0.0, max_val=20.0)]
+            )
         )
+
+    num_hidden_layers = kwargs["num_hidden_layers"]
+    input_features = kwargs["in_features"]
+    hidden_layers = []
+    for i in range(num_hidden_layers + 1):
+        # Hidden activation is eventually added only to the hidden layers
+        # before the last FullyConnected layer. The same is for the batch norm
+        # layers.
+        hidden_layers.append(
+            FullyConnected(
+                in_features=input_features,
+                out_features=kwargs["hidden_size"]
+                if i < num_hidden_layers
+                else kwargs["out_features"],
+                hidden_activation_fn=kwargs["hidden_activation_fn"]
+                if i < num_hidden_layers
+                else None,
+                batch_norm=kwargs["batch_norm"]
+                if i < num_hidden_layers
+                else False,
+            )
+        )
+        input_features = kwargs["hidden_size"]
+
+    fully_connected_module = torch.nn.Sequential(*hidden_layers)
+
     if not return_kwargs:
-        return FullyConnected(**kwargs)
-    return FullyConnected(**kwargs), kwargs
+        return fully_connected_module
+    return fully_connected_module, kwargs
 
 
 # Tests -----------------------------------------------------------------------
@@ -48,129 +74,39 @@ def test_fully_connected_module_structure_correct_for_valid_kwargs(
 ):
     """Ensures FullyConnected.fully_connected structure is correct."""
     fully_connected, kwargs = fully_connected_kwargs
-    fully_connected = fully_connected.fully_connected  # get torch module
-
-    if kwargs["num_hidden_layers"] == 0:
-        assert isinstance(fully_connected, torch.nn.Linear)
-        assert fully_connected.in_features == kwargs["in_features"]
-        assert fully_connected.out_features == kwargs["out_features"]
-        return
 
     assert isinstance(fully_connected, torch.nn.Sequential)
-    assert len(fully_connected) == 2 * kwargs["num_hidden_layers"] + 1
+
+    if kwargs["num_hidden_layers"] == 0:
+        assert isinstance(fully_connected[0].fully_connected, torch.nn.Linear)
+        assert (
+            fully_connected[0].fully_connected.in_features
+            == kwargs["in_features"]
+        )
+        assert (
+            fully_connected[0].fully_connected.out_features
+            == kwargs["out_features"]
+        )
+        return
+
+    assert len(fully_connected) == kwargs["num_hidden_layers"] + 1
 
     in_features = kwargs["in_features"]
     for idx, module in enumerate(fully_connected):
-        # should be alternating linear/activation_fn layers
-        if idx % 2 == 0:
-            assert isinstance(module, torch.nn.Linear)
-            assert module.in_features == in_features
-            if idx == len(fully_connected) - 1:
-                assert module.out_features == kwargs["out_features"]
-            else:
-                assert module.out_features == kwargs["hidden_size"]
-            in_features = kwargs["hidden_size"]
+        # should be alternating linear/batch_norm/activation_fn layers
+        assert isinstance(module.fully_connected, torch.nn.Linear)
+        assert module.fully_connected.in_features == in_features
+        if idx == len(fully_connected) - 1:
+            assert (
+                module.fully_connected.out_features == kwargs["out_features"]
+            )
         else:
-            assert isinstance(module, type(kwargs["hidden_activation_fn"]))
+            assert module.fully_connected.out_features == kwargs["hidden_size"]
+            in_features = kwargs["hidden_size"]
 
-
-@given(
-    fully_connected=fully_connecteds(),
-    batch_size=st.integers(min_value=1, max_value=16),
-    max_seq_len=st.integers(min_value=1, max_value=64),
-)
-def test_fully_connected_module_returns_correct_seq_lens(
-    fully_connected: FullyConnected, batch_size: int, max_seq_len: int
-):
-    """Ensures FullyConnected returns correct seq_lens when support enabled."""
-    tensor = torch.empty(
-        [max_seq_len, batch_size, fully_connected.in_features],
-        requires_grad=False,
-    ).normal_()
-
-    in_seq_lens = torch.randint(
-        low=1,
-        high=max_seq_len + 1,
-        size=[batch_size],
-        dtype=torch.int32,
-        requires_grad=False,
-    )
-
-    _, act_seq_lens = fully_connected((tensor, in_seq_lens))
-
-    assert torch.all(act_seq_lens == in_seq_lens)
-
-
-@given(
-    fully_connected_kwargs=fully_connecteds(return_kwargs=True),
-    num_hidden_layers=st.integers(-1000, -1),
-)
-def test_fully_connected_raises_value_error_negative_num_hidden_layers(
-    fully_connected_kwargs: Tuple[FullyConnected, Dict], num_hidden_layers: int
-) -> None:
-    """Ensures ValueError raised when num_hidden_layers < 0."""
-    _, kwargs = fully_connected_kwargs
-    kwargs["num_hidden_layers"] = num_hidden_layers
-    with pytest.raises(ValueError):
-        FullyConnected(**kwargs)
-
-
-@given(
-    fully_connected_kwargs=fully_connecteds(return_kwargs=True),
-    hidden_size=st.integers(1, 1000),
-)
-def test_fully_connected_raises_value_error_hidden_size_not_none(
-    fully_connected_kwargs: Tuple[FullyConnected, Dict], hidden_size: int
-) -> None:
-    """Ensures ValueError raised when no hidden layers and not hidden_size."""
-    _, kwargs = fully_connected_kwargs
-    kwargs["num_hidden_layers"] = 0
-    kwargs["hidden_size"] = hidden_size
-    with pytest.raises(ValueError):
-        FullyConnected(**kwargs)
-
-
-@given(
-    fully_connected_kwargs=fully_connecteds(return_kwargs=True),
-    hidden_activation_fn=st.sampled_from([torch.nn.ReLU(), torch.nn.Tanh()]),
-)
-def test_fully_connected_raises_value_error_hidden_activation_fn_not_none(
-    fully_connected_kwargs: Tuple[FullyConnected, Dict],
-    hidden_activation_fn: torch.nn.Module,
-) -> None:
-    """Ensures ValueError raised when no hidden layers and no act fn."""
-    _, kwargs = fully_connected_kwargs
-    kwargs["num_hidden_layers"] = 0
-    kwargs["hidden_activation_fn"] = hidden_activation_fn
-    with pytest.raises(ValueError):
-        FullyConnected(**kwargs)
-
-
-@given(
-    fully_connected_kwargs=fully_connecteds(return_kwargs=True),
-    tensor=tensors(min_n_dims=3, max_n_dims=3),
-)
-def test_fully_connected_forward_returns_correct_size(
-    fully_connected_kwargs: Tuple[FullyConnected, Dict], tensor: torch.Tensor
-) -> None:
-    # create new FullyConnected that accepts in_features sized input
-    _, kwargs = fully_connected_kwargs
-    kwargs["in_features"] = tensor.size()[-1]
-    fully_connected = FullyConnected(**kwargs)
-
-    max_seq_len, batch_size, *_ = tensor.size()
-    in_seq_lens = torch.randint(
-        low=1,
-        high=max_seq_len + 1,
-        size=[batch_size],
-        dtype=torch.int32,
-        requires_grad=False,
-    )
-    out, _ = fully_connected((tensor, in_seq_lens))
-
-    in_size = tensor.size()
-    out_size = out.size()
-
-    assert len(in_size) == len(out_size)
-    assert in_size[:-1] == out_size[:-1]
-    assert out_size[-1] == kwargs["out_features"]
+            if kwargs["batch_norm"] and idx < kwargs["num_hidden_layers"]:
+                assert isinstance(module.batch_norm, torch.nn.BatchNorm1d)
+            if idx < kwargs["num_hidden_layers"]:
+                assert isinstance(
+                    module.activation, type(kwargs["hidden_activation_fn"])
+                )

--- a/tests/model/test_rnn.py
+++ b/tests/model/test_rnn.py
@@ -47,7 +47,6 @@ def test_correct_rnn_type_and_size_returned(
         rnn_type=rnn_type,
         input_size=input_size,
         hidden_size=hidden_size,
-        num_layers=num_layers,
         bias=bias,
         # warning raised when num_layers > 1 and dropout != 0.0 as this option
         # set does not make sense

--- a/tests/model/test_rnn.py
+++ b/tests/model/test_rnn.py
@@ -1,5 +1,3 @@
-import math
-
 import hypothesis.strategies as st
 import pytest
 import torch
@@ -24,23 +22,21 @@ def rnn_types(draw) -> st.SearchStrategy[RNNType]:
     rnn_type=rnn_types(),
     input_size=st.integers(min_value=1, max_value=128),
     hidden_size=st.integers(min_value=1, max_value=128),
-    num_layers=st.integers(min_value=1, max_value=4),
     bias=st.booleans(),
-    dropout=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
     bidirectional=st.booleans(),
     forget_gate_bias=st.one_of(
         st.none(), st.floats(min_value=-10.0, max_value=10.0, allow_nan=False)
     ),
+    batch_norm=st.booleans(),
 )
 def test_correct_rnn_type_and_size_returned(
     rnn_type: RNNType,
     input_size: int,
     hidden_size: int,
-    num_layers: int,
     bias: int,
-    dropout: float,
     bidirectional: bool,
     forget_gate_bias: float,
+    batch_norm: bool,
 ) -> None:
     """Ensures correct ``rnn`` type and initialisation."""
     rnn = RNN(
@@ -50,9 +46,10 @@ def test_correct_rnn_type_and_size_returned(
         bias=bias,
         # warning raised when num_layers > 1 and dropout != 0.0 as this option
         # set does not make sense
-        dropout=0.0 if num_layers == 1 else dropout,
+        dropout=0.0,
         bidirectional=bidirectional,
         forget_gate_bias=forget_gate_bias,
+        batch_norm=batch_norm,
     )
 
     if rnn_type == RNNType.LSTM:
@@ -66,24 +63,21 @@ def test_correct_rnn_type_and_size_returned(
 
     assert rnn.rnn.input_size == input_size
     assert rnn.rnn.hidden_size == hidden_size
-    assert rnn.rnn.num_layers == num_layers
     assert rnn.rnn.bias == bias
     assert not rnn.rnn.batch_first
-    if num_layers > 1:
-        assert math.isclose(rnn.rnn.dropout, dropout)
     assert rnn.rnn.bidirectional == bidirectional
+
+    if batch_norm:
+        assert isinstance(rnn.batch_norm, torch.nn.BatchNorm1d)
 
     if not (
         rnn_type == RNNType.LSTM and bias and forget_gate_bias is not None
     ):
         return
 
-    for l in range(num_layers):
-        bias = getattr(rnn.rnn, f"bias_ih_l{l}")[hidden_size : 2 * hidden_size]
-        bias += getattr(rnn.rnn, f"bias_hh_l{l}")[
-            hidden_size : 2 * hidden_size
-        ]
-        assert torch.allclose(bias, torch.tensor(forget_gate_bias))
+    bias = getattr(rnn.rnn, f"bias_ih_l0")[hidden_size : 2 * hidden_size]
+    bias += getattr(rnn.rnn, f"bias_hh_l0")[hidden_size : 2 * hidden_size]
+    assert torch.allclose(bias, torch.tensor(forget_gate_bias))
 
 
 @given(rnn_type=st.integers(min_value=100, max_value=300))

--- a/tests/protos/test_deep_speech_2.py
+++ b/tests/protos/test_deep_speech_2.py
@@ -61,6 +61,7 @@ def _conv_blocks(
         else:
             kwargs["conv2d"] = convnd
 
+        kwargs["batch_norm"] = draw(st.booleans())
         kwargs["activation"] = draw(activations())
 
         return deep_speech_2_pb2.DeepSpeech2.ConvBlock(**kwargs)

--- a/tests/protos/test_fully_connected.py
+++ b/tests/protos/test_fully_connected.py
@@ -33,6 +33,7 @@ def fully_connecteds(
     else:
         kwargs["hidden_size"] = draw(st.integers(1, 32))
         kwargs["activation"] = draw(activations())
+    kwargs["batch_norm"] = draw(st.booleans())
 
     all_fields_set(fully_connected_pb2.FullyConnected, kwargs)
     fc = fully_connected_pb2.FullyConnected(**kwargs)

--- a/tests/protos/test_rnn.py
+++ b/tests/protos/test_rnn.py
@@ -28,6 +28,7 @@ def rnns(
     kwargs["num_layers"] = draw(st.integers(1, 4))
     kwargs["bias"] = draw(st.booleans())
     kwargs["bidirectional"] = draw(st.booleans())
+    kwargs["batch_norm"] = draw(st.booleans())
     if kwargs["rnn_type"] == rnn_pb2.RNN.RNN_TYPE.LSTM and kwargs["bias"]:
         kwargs["forget_gate_bias"] = FloatValue(
             value=draw(


### PR DESCRIPTION
Added batch normalization to rnn, convolution and fully connected layers + Fixed all tests.
The way all layers are built seems to be changed a lot but it is simply because it is now necessary to build separately all layers in order to insert batch norm between them.
Example: instead of calling torch.nn.LSTM once and passing the number of layers as an argument, it is now necessary to call this function num_layers time.