### PR TITLE
Config fix

### DIFF
--- a/src/myrtlespeech/configs/deep_speech_1_en.config
+++ b/src/myrtlespeech/configs/deep_speech_1_en.config
@@ -50,6 +50,7 @@ train_config {
   adam {
     learning_rate: 0.0003;
   }
+  constant_lr {};
   dataset {
     librispeech {
       root: "/data/";

--- a/tests/configs/test_configs.py
+++ b/tests/configs/test_configs.py
@@ -1,4 +1,5 @@
 import os
+import re
 from glob import glob
 
 import google.protobuf.text_format as text_format  # weird import for mypy
@@ -25,4 +26,17 @@ def test_all_configs_build(config_path):
     """Ensures all `myrtlespeech/config/*.config` files parse."""
     with open(config_path, "r") as config_file:
         config = config_file.read()
+    text_format.Merge(config, task_config_pb2.TaskConfig())
+
+
+def test_model_in_configs_can_be_built(config_path):
+    """Ensures :py:class:`seq_to_seq` in config file can be built.
+
+    Does not build the whole task config as the
+    """
+    with open(config_path, "r") as config_file:
+        config = config_file.read()
+
+    re.split("{|}", config)
+
     text_format.Merge(config, task_config_pb2.TaskConfig())

--- a/tests/configs/test_configs.py
+++ b/tests/configs/test_configs.py
@@ -1,11 +1,78 @@
 import os
-import re
 from glob import glob
 
 import google.protobuf.text_format as text_format  # weird import for mypy
 import pytest
 from myrtlespeech import configs
+from myrtlespeech.builders.task_config import build
 from myrtlespeech.protos import task_config_pb2
+
+# Utilities -------------------------------------------------------------------
+
+DATASET_STR = "dataset "
+FAKE_DSET = """{
+fake_speech_to_text {
+    dataset_len: 2;
+    audio_ms {
+        lower: 1;
+        upper: 10;
+        }
+    label_symbols: "abc";
+    label_len {
+        lower: 1;
+        upper: 10;
+        }
+    }
+}"""
+
+
+def replace_dataset_w_fake_dataset(config):
+    """Replaces dataset in string config with fake_speech_to_text.
+
+    It does this by stepping through the config string one character at a time.
+
+    Note: this function looks for the sequence :py:data:`dataset `
+    so this test will fail if any other elemtents of the proto (valid or not)
+    contain this string.
+    """
+    dset_count = 0  # Number of times DATASET_STR has been found
+    dset_idx = 0  # Current index in DATASET_STR
+    reading_dataset = False  # If True, DATASET_STR is currently being read
+    config_out = ""  # Config string that will be returned
+    for idx, char in enumerate(config):
+        if dset_idx == len(DATASET_STR):
+            reading_dataset = True
+            dset_idx = 0
+            bracket_depth = 0  # tracks depth inside brackets
+            entered_brackets = False  # ensure brackets are entered to depth
+            # of at least one
+        if not reading_dataset:
+            if char == DATASET_STR[dset_idx]:
+                dset_idx += 1
+            else:
+                dset_idx = 0
+            config_out += char  # Add char unchanged
+        else:
+            if char == "{":
+                bracket_depth += 1
+                entered_brackets = True
+            elif char == "}":
+                bracket_depth -= 1
+            else:
+                # char **not** added whilst reading_dataset = True
+                pass
+
+            if bracket_depth == 0 and entered_brackets:
+                # ... then we have reached end of dataset config string
+                config_out += FAKE_DSET
+                dset_count += 1
+                reading_dataset = False
+    if dset_count != 2:
+        raise ValueError(
+            f"The string `dataset ` should appear exactly twice in a valid "
+            f"config file but it appears {dset_count} times"
+        )
+    return config_out
 
 
 # Fixtures and Strategies -----------------------------------------------------
@@ -32,11 +99,12 @@ def test_all_configs_build(config_path):
 def test_model_in_configs_can_be_built(config_path):
     """Ensures :py:class:`seq_to_seq` in config file can be built.
 
-    Does not build the whole task config as the
+    This attempst to build the task config **minus the dataset** which is
+    replaced with fake_speech_to_text for speed.
     """
     with open(config_path, "r") as config_file:
         config = config_file.read()
 
-    re.split("{|}", config)
-
-    text_format.Merge(config, task_config_pb2.TaskConfig())
+    new_config = replace_dataset_w_fake_dataset(config)
+    compiled = text_format.Merge(new_config, task_config_pb2.TaskConfig())
+    build(compiled)

--- a/tests/configs/test_configs.py
+++ b/tests/configs/test_configs.py
@@ -9,70 +9,15 @@ from myrtlespeech.protos import task_config_pb2
 
 # Utilities -------------------------------------------------------------------
 
-DATASET_STR = "dataset "
-FAKE_DSET = """{
-fake_speech_to_text {
-    dataset_len: 2;
-    audio_ms {
-        lower: 1;
-        upper: 10;
-        }
-    label_symbols: "abc";
-    label_len {
-        lower: 1;
-        upper: 10;
-        }
-    }
-}"""
-
 
 def replace_dataset_w_fake_dataset(config):
-    """Replaces dataset in string config with fake_speech_to_text.
-
-    It does this by stepping through the config string one character at a time.
-
-    Note: this function looks for the sequence :py:data:`dataset `
-    so this test will fail if any other elemtents of the proto (valid or not)
-    contain this string.
-    """
-    dset_count = 0  # Number of times DATASET_STR has been found
-    dset_idx = 0  # Current index in DATASET_STR
-    reading_dataset = False  # If True, DATASET_STR is currently being read
-    config_out = ""  # Config string that will be returned
-    for idx, char in enumerate(config):
-        if dset_idx == len(DATASET_STR):
-            reading_dataset = True
-            dset_idx = 0
-            bracket_depth = 0  # tracks depth inside brackets
-            entered_brackets = False  # ensure brackets are entered to depth
-            # of at least one
-        if not reading_dataset:
-            if char == DATASET_STR[dset_idx]:
-                dset_idx += 1
-            else:
-                dset_idx = 0
-            config_out += char  # Add char unchanged
-        else:
-            if char == "{":
-                bracket_depth += 1
-                entered_brackets = True
-            elif char == "}":
-                bracket_depth -= 1
-            else:
-                # char **not** added whilst reading_dataset = True
-                pass
-
-            if bracket_depth == 0 and entered_brackets:
-                # ... then we have reached end of dataset config string
-                config_out += FAKE_DSET
-                dset_count += 1
-                reading_dataset = False
-    if dset_count != 2:
-        raise ValueError(
-            f"The string `dataset ` should appear exactly twice in a valid "
-            f"config file but it appears {dset_count} times"
-        )
-    return config_out
+    """Replaces dataset proto config with fake_speech_to_text."""
+    config.fake_speech_to_text.dataset_len = 2
+    config.fake_speech_to_text.audio_ms.lower = 1
+    config.fake_speech_to_text.audio_ms.upper = 10
+    config.fake_speech_to_text.label_symbols = "abc"
+    config.fake_speech_to_text.label_len.lower = 1
+    config.fake_speech_to_text.label_len.upper = 10
 
 
 # Fixtures and Strategies -----------------------------------------------------
@@ -97,14 +42,15 @@ def test_all_configs_build(config_path):
 
 
 def test_model_in_configs_can_be_built(config_path):
-    """Ensures :py:class:`seq_to_seq` in config file can be built.
+    """Ensures :py:class:`task_config` in .config file can be built.
 
-    This attempst to build the task config **minus the dataset** which is
+    This attempts to build the task config **minus the dataset** which is
     replaced with fake_speech_to_text for speed.
     """
     with open(config_path, "r") as config_file:
         config = config_file.read()
 
-    new_config = replace_dataset_w_fake_dataset(config)
-    compiled = text_format.Merge(new_config, task_config_pb2.TaskConfig())
+    compiled = text_format.Merge(config, task_config_pb2.TaskConfig())
+    replace_dataset_w_fake_dataset(compiled.train_config.dataset)
+    replace_dataset_w_fake_dataset(compiled.eval_config.dataset)
     build(compiled)


### PR DESCRIPTION
An update to master broke one of the existing configs. This failure was silent because the proto parsed correctly but the builder threw an exception.  

To help avoid this in future I've added a test that builds all configs (replacing the dataset with `fake_speech_to_text` for speed). 