### PR TITLE
Speed Perturbation

### DIFF
--- a/docs/source/myrtlespeech/data/preprocess.rst
+++ b/docs/source/myrtlespeech/data/preprocess.rst
@@ -27,6 +27,12 @@
 
     .. automethod:: __call__
 
+.. autoclass:: myrtlespeech.data.preprocess.SpeedPerturbation
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __call__
+
 
 .. autoclass:: myrtlespeech.data.preprocess.SpecAugment
     :members:

--- a/src/myrtlespeech/builders/pre_process_step.py
+++ b/src/myrtlespeech/builders/pre_process_step.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from myrtlespeech.data.preprocess import AddContextFrames
 from myrtlespeech.data.preprocess import SpecAugment
+from myrtlespeech.data.preprocess import SpeedPerturbation
 from myrtlespeech.data.preprocess import Standardize
 from myrtlespeech.protos import pre_process_step_pb2
 from myrtlespeech.run.stage import Stage
@@ -11,7 +12,7 @@ from torchaudio.transforms import MFCC
 
 def build(
     pre_process_step_cfg: pre_process_step_pb2.PreProcessStep,
-) -> Tuple[Union[MFCC, Standardize], Stage]:
+) -> Tuple[Union[MFCC, SpeedPerturbation, Standardize], Stage]:
     """Returns tuple of ``(preprocessing callable, stage)``.
 
     Args:
@@ -32,6 +33,11 @@ def build(
                 "win_length": pre_process_step_cfg.mfcc.win_length,
                 "hop_length": pre_process_step_cfg.mfcc.hop_length,
             },
+        )
+    elif step_type == "speed_perturbation":
+        step = SpeedPerturbation(
+            min_speed=pre_process_step_cfg.speed_perturbation.min_speed,
+            max_speed=pre_process_step_cfg.speed_perturbation.max_speed,
         )
     elif step_type == "spec_augment":
         spec = pre_process_step_cfg.spec_augment

--- a/src/myrtlespeech/data/preprocess.py
+++ b/src/myrtlespeech/data/preprocess.py
@@ -145,7 +145,25 @@ class AddContextFrames:
 
 
 class SpeedPerturbation:
-    """TODO"""
+    """Applies SpeedPerturbation augmentation.
+
+    `SpeedPerturbation
+    <https://www.danielpovey.com/files/2015_interspeech_augmentation.pdf>`_. # noqa: E501
+    will be applied at a random speed chosen uniformly in
+    ``[min_speed, max_speed]``.
+
+    Args:
+        min_speed: The minimum ratio of original to final speed.
+
+        max_speed: The minimum ratio of original to final speed.
+
+        frequency: Desired frequency of output audio.
+
+    Raises:
+        :py:class:`ValueError`: ``if not (0.1 < min_speed <= 1.0)``.
+
+        :py:class:`ValueError`: ``if not (1.0 <= max_speed < 10.0)``.
+    """
 
     def __init__(
         self, min_speed: float, max_speed: float, frequency: int = 16000,

--- a/src/myrtlespeech/data/preprocess.py
+++ b/src/myrtlespeech/data/preprocess.py
@@ -148,7 +148,7 @@ class SpeedPerturbation:
     """Applies SpeedPerturbation augmentation.
 
     `SpeedPerturbation
-    <https://www.danielpovey.com/files/2015_interspeech_augmentation.pdf>`_. # noqa: E501
+    <https://www.danielpovey.com/files/2015_interspeech_augmentation.pdf>`_
     will be applied at a random speed chosen uniformly in
     ``[min_speed, max_speed]``.
 

--- a/src/myrtlespeech/model/seq_to_seq.py
+++ b/src/myrtlespeech/model/seq_to_seq.py
@@ -15,24 +15,42 @@ class SeqToSeq(torch.nn.Module):
 
         loss: A :py:class:`torch.nn.Module` to compute the loss.
 
-        pre_process_steps: A sequence of preprocessing steps. For each
-            ``(callable, stage)`` tuple in the sequence, the ``callable``
-            should accept as input the output from the previous ``callable`` in
-            the sequence or raw data if it is the first. The ``callable``
-            should only be applied when the current training stage matches
-            ``stage``.  :py:data:`.SeqToSeq.pre_process` returns a ``Callable``
-            that handles this automatically based on
-            :py:class:`.SeqToSeq.training`.
+        pre_process_steps: A Tuple ``(pre_load_transforms,
+            post_load_transforms)``. See Attributes for more information.
 
         optim: An optional :py:class:`torch.optim.Optimizer` initialized with
             model parameters to update.
+
+    Attributes:
+        pre_load_transforms: A sequence of preprocessing steps to be applied
+            during loading of audio file. For each ``(callable, stage)`` Tuple
+            in the sequence, the ``callable`` should accept as input the
+            output from the previous ``callable`` in the sequence or a
+            filepath if it is the first. ``callable`` should only be applied
+            when the current training stage matches ``stage``.
+            :py:data:`.SeqToSeq.pre_load_transforms` returns a ``Callable``
+            that handles this automatically based on
+            :py:class:`.SeqToSeq.training`.
+
+        post_load_transforms: A sequence of preprocessing steps to be applied
+            to audio :py:class`torch.Tensor`. For each ``(callable, stage)``
+            Tuple in the sequence, the ``callable`` should accept as input the
+            output from the previous ``callable`` in the sequence or the
+            loaded audio if it is the first.
+            :py:data:`.SeqToSeq.post_load_transforms` returns a ``Callable``
+            that handles this automatically based on
+            :py:class:`.SeqToSeq.training`.
+
+
     """
 
     def __init__(
         self,
         model: torch.nn.Module,
         loss: torch.nn.Module,
-        pre_process_steps: Sequence[Tuple[Callable, Stage]],
+        pre_process_steps: Tuple[
+            Sequence[Tuple[Callable, Stage]], Sequence[Tuple[Callable, Stage]]
+        ],
         optim: Optional[torch.optim.Optimizer] = None,
     ):
         super().__init__()
@@ -45,12 +63,21 @@ class SeqToSeq(torch.nn.Module):
         if self.use_cuda:
             self.model = self.model.cuda()
 
-    @property
-    def pre_process(self) -> Callable:
+    def _get_pre_process(self, pre_process_type: str) -> Optional[Callable]:
         """See Args."""
+        if pre_process_type == "post_load":
+            step_and_stages = self.pre_process_steps[1]
+        elif pre_process_type == "pre_load":
+            step_and_stages = self.pre_process_steps[0]
+        else:
+            raise ValueError(
+                f"pre_process_type = {pre_process_type} not " "not recognized."
+            )
+        if not step_and_stages:
+            return None
 
         def process(x):
-            for step, stage in self.pre_process_steps:
+            for step, stage in step_and_stages:
                 if stage is Stage.TRAIN and not self.training:
                     continue
                 if stage is Stage.EVAL and self.training:
@@ -59,3 +86,11 @@ class SeqToSeq(torch.nn.Module):
             return x
 
         return process
+
+    @property
+    def pre_load_transforms(self) -> Optional[Callable]:
+        return self._get_pre_process("pre_load")
+
+    @property
+    def post_load_transforms(self) -> Optional[Callable]:
+        return self._get_pre_process("post_load")

--- a/src/myrtlespeech/protos/pre_process_step.proto
+++ b/src/myrtlespeech/protos/pre_process_step.proto
@@ -14,6 +14,7 @@ message PreProcessStep {
     Standardize standardize = 3;
     ContextFrames context_frames = 4;
     SpecAugment spec_augment = 5;
+    SpeedPerturbation speed_perturbation = 6;
   }
 }
 
@@ -27,6 +28,19 @@ message MFCC {
 
   // Step between successive windows in number of frames.
   uint32 hop_length = 3;
+}
+
+
+// Applies SpeedPerturbation transformation (https://www.danielpovey.com/files/2015_interspeech_augmentation.pdf).
+// This augmentation is applied to the raw audio signal and therefore,
+// if present, SpeedPerturbation must be applied before any frequency-based
+// feature extraction technique (e.g. MFCC).
+message SpeedPerturbation {
+  // Minimum speed ratio vs. original signal.
+  float min_speed = 1;
+
+  // Maximum speed ratio vs. original signal.
+  float max_speed = 2;
 }
 
 

--- a/tests/builders/test_dataset.py
+++ b/tests/builders/test_dataset.py
@@ -74,7 +74,11 @@ def test_build_passes_transform_to_fake_speech_to_text(
     target_transform = lambda x: "target transform"  # noqa: E731
 
     dataset = build(
-        dataset_cfg, transform, target_transform, add_seq_len_to_transforms
+        dataset=dataset_cfg,
+        pre_load_transform=None,
+        post_load_transform=transform,
+        target_transform=target_transform,
+        add_seq_len_to_transforms=add_seq_len_to_transforms,
     )
 
     for audio, label in dataset:

--- a/tests/builders/test_pre_process_step.py
+++ b/tests/builders/test_pre_process_step.py
@@ -6,6 +6,7 @@ from hypothesis import given
 from myrtlespeech.builders.pre_process_step import build
 from myrtlespeech.data.preprocess import AddContextFrames
 from myrtlespeech.data.preprocess import SpecAugment
+from myrtlespeech.data.preprocess import SpeedPerturbation
 from myrtlespeech.data.preprocess import Standardize
 from myrtlespeech.protos import pre_process_step_pb2
 from myrtlespeech.run.stage import Stage
@@ -15,6 +16,7 @@ from tests.protos.test_pre_process_step import pre_process_steps
 
 
 # Utilities -------------------------------------------------------------------
+TOL = 1e-8
 
 
 def pre_process_step_match_cfg(
@@ -31,6 +33,16 @@ def pre_process_step_match_cfg(
         assert step[0].n_mfcc == step_cfg.mfcc.n_mfcc
         assert step[0].MelSpectrogram.win_length == step_cfg.mfcc.win_length
         assert step[0].MelSpectrogram.hop_length == step_cfg.mfcc.hop_length
+    elif step_str == "speed_perturbation":
+        assert isinstance(step[0], SpeedPerturbation)
+        assert (
+            abs(step[0].min_speed - step_cfg.speed_perturbation.min_speed)
+            < TOL
+        )
+        assert (
+            abs(step[0].max_speed - step_cfg.speed_perturbation.max_speed)
+            < TOL
+        )
     elif step_str == "spec_augment":
         assert isinstance(step[0], SpecAugment)
     elif step_str == "standardize":

--- a/tests/protos/test_pre_process_step.py
+++ b/tests/protos/test_pre_process_step.py
@@ -36,6 +36,8 @@ def pre_process_steps(
 
     if step_type_str == "mfcc":
         kwargs["mfcc"] = draw(_mfccs())
+    elif step_type_str == "speed_perturbation":
+        kwargs["speed_perturbation"] = draw(_speed_perturbation())
     elif step_type_str == "spec_augment":
         kwargs["spec_augment"] = draw(_spec_augments())
     elif step_type_str == "standardize":
@@ -73,6 +75,27 @@ def _mfccs(
     if not return_kwargs:
         return mfcc
     return mfcc, kwargs
+
+
+@st.composite
+def _speed_perturbation(
+    draw, return_kwargs: bool = False
+) -> Union[
+    st.SearchStrategy[pre_process_step_pb2.SpeedPerturbation],
+    st.SearchStrategy[Tuple[pre_process_step_pb2.SpeedPerturbation, Dict]],
+]:
+    """Returns a SearchStrategy for SpecAugments plus maybe the kwargs."""
+    kwargs: Dict = {}
+
+    kwargs["min_speed"] = draw(st.floats(0.7, 1.0))
+    kwargs["max_speed"] = draw(st.floats(1.0, 1.3))
+
+    # initialise and return
+    all_fields_set(pre_process_step_pb2.SpeedPerturbation, kwargs)
+    speed_p = pre_process_step_pb2.SpeedPerturbation(**kwargs)  # type: ignore
+    if not return_kwargs:
+        return speed_p
+    return speed_p, kwargs
 
 
 @st.composite

--- a/tests/protos/test_speech_to_text.py
+++ b/tests/protos/test_speech_to_text.py
@@ -37,8 +37,18 @@ def speech_to_texts(
     # preprocess step
     kwargs["pre_process_step"] = []
     if draw(st.booleans()):
-        kwargs["pre_process_step"].append(draw(pre_process_steps()))
-
+        pre_process = draw(pre_process_steps())
+        kwargs["pre_process_step"].append(pre_process)
+        if pre_process.WhichOneof("pre_process_step") == "speed_perturbation":
+            assume(
+                pre_process.WhichOneof("pre_process_step")
+                != "speed_perturbation"
+            )
+            warnings.warn(
+                "Unable to test speed_perturbation in full task config since "
+                "only fake_speech_to_text Dataset is supported and this is "
+                "incompatible with speed_perturbation."
+            )
     # record input_features and input_channels to ensure built model is valid
     _, input_features, input_channels = _build_pre_process_steps(
         kwargs["pre_process_step"]


### PR DESCRIPTION
Adds speed perturbation. 

This introduces non-trivial changes to the pre-processing pipeline so it's worth giving a bit of background on why I've taken this approach. Some of this is a repetition of an earlier slack message. 
 
**TL;DR: it is necessary to use `torchaudio.sox_effect_chain` which adds a large amount of complexity.**

### 'Simpler' alternatives to using `sox`
I've tried x2 multiple _other_ ways of performing speed-perturbation:
1) Using another library `librosa`. NVIDIA use this (https://github.com/ryanleary/mlperf-rnnt-ref/blob/fe0cc4145c240d4f8a8fe1814f397df63095e220/parts/perturb.py#L42) 
2) Using `torchaudio.Resample` to perform directly on the input tensor. 

Both of these are **very** slow. 1. converts to the frequency domain and back while 2. is even slower when upsampling the signal (i.e. making it slower). For reference on `copernicus` the methods are respectively `x20` and `x300` slower (!) than the `sox` implementation and the dataloaders become the limiting factors during training.
For comparison, the `sox` version does add some overhead but this is acceptable (+25% time per epoch - and this includes the fact that some sequences are 15% longer.)

A third potential method (which NVIDIA also use: https://github.com/ryanleary/mlperf-rnnt-ref/blob/fe0cc4145c240d4f8a8fe1814f397df63095e220/utils/preprocessing_utils.py#L52) is performing the perturbation offline. This seems like a poor choice to me since:
a) Each training sample has a fixed speed change - reducing augmentation effectiveness
b) This isn't scalable with training set size (to 60k/100k hrs) as the multiple dataset copies won't fit on the disk of a single machine.

### Necessary changes
The complexity added by `sox_effects_chain` is that it must be applied on a filepath rather than a tensor. To deal with this I've split the audio transforms into two types: 
1) `pre_load_transforms` - speed_perturbation is of this type
2) `post_load_transforms` - all previous transforms are of this type

FYI, the high-level API treats `speed_pertubation` in exactly the same way as other steps but I've found it necessary for the `builders` + `dataset` to have knowledge of the two transform types.

It is also necessary to add a `worker_init_fn` to avoid seg_faults when sox is being used :scream: - I think the lack of this fn lead samG to think that `sox` wasn't thread-safe. 