### PR TITLE
Updated CSVLogger so that it no longer overwrites old csv logs

### DIFF
--- a/src/myrtlespeech/run/run.py
+++ b/src/myrtlespeech/run/run.py
@@ -229,9 +229,7 @@ def run() -> None:
     if args.stop_epoch_after is not None:
         callbacks.append(StopEpochAfter(epoch_batches=args.stop_epoch_after))
 
-    callbacks.extend(
-        [CSVLogger(log_dir.joinpath("log.csv")), Saver(log_dir, seq_to_seq)]
-    )
+    callbacks.extend([CSVLogger(log_dir), Saver(log_dir, seq_to_seq)])
 
     # train and evaluate
     fit(


### PR DESCRIPTION
V. small PR to make CSVLogger more amenable to crashed training runs. 

Each file is now saved in `log_dir` with a unique `datetime.isoformat` name