### PR TITLE
Adds legacy MFCC

### DIFF
--- a/docs/source/myrtlespeech/data/preprocess.rst
+++ b/docs/source/myrtlespeech/data/preprocess.rst
@@ -6,6 +6,11 @@
     :members:
     :show-inheritance:
 
+.. autoclass:: myrtlespeech.data.preprocess.MFCCLegacy
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __call__
 
 .. autoclass:: myrtlespeech.data.preprocess.AddSequenceLength
     :members:
@@ -29,12 +34,6 @@
 
 
 .. autoclass:: myrtlespeech.data.preprocess.SpecAugment
-    :members:
-    :show-inheritance:
-
-    .. automethod:: __call__
-
-.. autoclass:: myrtlespeech.data.preprocess.MFCCLegacy
     :members:
     :show-inheritance:
 

--- a/docs/source/myrtlespeech/data/preprocess.rst
+++ b/docs/source/myrtlespeech/data/preprocess.rst
@@ -33,3 +33,9 @@
     :show-inheritance:
 
     .. automethod:: __call__
+
+.. autoclass:: myrtlespeech.data.preprocess.MFCCLegacy
+    :members:
+    :show-inheritance:
+
+    .. automethod:: __call__

--- a/src/myrtlespeech/builders/pre_process_step.py
+++ b/src/myrtlespeech/builders/pre_process_step.py
@@ -1,7 +1,9 @@
+from typing import Callable
 from typing import Tuple
 from typing import Union
 
 from myrtlespeech.data.preprocess import AddContextFrames
+from myrtlespeech.data.preprocess import MFCCLegacy
 from myrtlespeech.data.preprocess import SpecAugment
 from myrtlespeech.data.preprocess import Standardize
 from myrtlespeech.protos import pre_process_step_pb2
@@ -25,8 +27,14 @@ def build(
         :py:class:`ValueError`: On invalid configuration.
     """
     step_type = pre_process_step_cfg.WhichOneof("pre_process_step")
+    step: Callable
     if step_type == "mfcc":
-        step = MFCC(
+        legacy = pre_process_step_cfg.mfcc.legacy
+        if legacy:
+            MFCC_cls = MFCCLegacy
+        else:
+            MFCC_cls = MFCC
+        step = MFCC_cls(
             n_mfcc=pre_process_step_cfg.mfcc.n_mfcc,
             melkwargs={
                 "win_length": pre_process_step_cfg.mfcc.win_length,

--- a/src/myrtlespeech/builders/pre_process_step.py
+++ b/src/myrtlespeech/builders/pre_process_step.py
@@ -1,4 +1,3 @@
-from typing import Callable
 from typing import Tuple
 from typing import Union
 
@@ -13,7 +12,9 @@ from torchaudio.transforms import MFCC
 
 def build(
     pre_process_step_cfg: pre_process_step_pb2.PreProcessStep,
-) -> Tuple[Union[MFCC, Standardize], Stage]:
+) -> Tuple[
+    Union[AddContextFrames, MFCC, MFCCLegacy, SpecAugment, Standardize], Stage
+]:
     """Returns tuple of ``(preprocessing callable, stage)``.
 
     Args:
@@ -27,14 +28,13 @@ def build(
         :py:class:`ValueError`: On invalid configuration.
     """
     step_type = pre_process_step_cfg.WhichOneof("pre_process_step")
-    step: Callable
     if step_type == "mfcc":
         legacy = pre_process_step_cfg.mfcc.legacy
         if legacy:
             MFCC_cls = MFCCLegacy
         else:
             MFCC_cls = MFCC
-        step = MFCC_cls(
+        step: Union[MFCC, MFCCLegacy] = MFCC_cls(
             n_mfcc=pre_process_step_cfg.mfcc.n_mfcc,
             melkwargs={
                 "win_length": pre_process_step_cfg.mfcc.win_length,

--- a/src/myrtlespeech/builders/speech_to_text.py
+++ b/src/myrtlespeech/builders/speech_to_text.py
@@ -13,6 +13,7 @@ from myrtlespeech.builders.pre_process_step import (
 )
 from myrtlespeech.data.alphabet import Alphabet
 from myrtlespeech.data.preprocess import AddContextFrames
+from myrtlespeech.data.preprocess import MFCCLegacy
 from myrtlespeech.data.preprocess import SpecAugment
 from myrtlespeech.data.preprocess import Standardize
 from myrtlespeech.model.cnn import Conv1dTo2d
@@ -248,7 +249,7 @@ def _build_pre_process_steps(
     pre_process_steps: List[Tuple[Callable, Stage]] = []
     for step_cfg in pre_process_step_cfg:
         step = build_pre_process_step(step_cfg)
-        if isinstance(step[0], MFCC):
+        if isinstance(step[0], (MFCC, MFCCLegacy)):
             input_features = step[0].n_mfcc
         elif isinstance(step[0], SpecAugment):
             pass

--- a/src/myrtlespeech/data/preprocess.py
+++ b/src/myrtlespeech/data/preprocess.py
@@ -228,6 +228,26 @@ class SpecAugment:
 
 
 class MFCCLegacy:
+    """Legacy MFCC implementation using ``python_speech_features``.
+
+    This is required for backwards compatibility: **new users should not use
+    this class.** This class has the same API as
+    :py:class`torchaudio.transforms.MFCC`.
+
+    Args:
+        n_mfcc: Number of MFCC coefficients.
+
+        melkwargs: Dict containing mel-spectogram kwargs:
+
+            win_length:
+                Window length (in samples not ms.)
+
+            hop_length:
+                Stride length (in samples not ms.)
+
+        sample_rate: audio sample rate.
+    """
+
     def __init__(self, n_mfcc, melkwargs, sample_rate=16000):
         win_length = melkwargs.get("win_length")
         hop_length = melkwargs.get("hop_length")
@@ -257,6 +277,7 @@ class MFCCLegacy:
         self.unsqueeze = Lambda(lambda_fn=lambda x: x.unsqueeze(0))
 
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        """See :py:class:`torchaudio.transforms.MFCC`."""
         x = self.normalise(x)
         x = python_speech_features.mfcc(
             x,

--- a/src/myrtlespeech/data/preprocess.py
+++ b/src/myrtlespeech/data/preprocess.py
@@ -282,7 +282,7 @@ class MFCCLegacy:
             x: Input :py:class:`torch.Tensor` size ``[1, time_samples]``.
 
         Returns:
-            A :py:class:`torch.Tensor` of size ``[1, self.m_fcc, timesteps]``.
+            A :py:class:`torch.Tensor` of size ``[1, self.n_mfcc, timesteps]``.
         """
         # 1)
         # In the previous implementation, on file read, the data was converted

--- a/src/myrtlespeech/data/preprocess.py
+++ b/src/myrtlespeech/data/preprocess.py
@@ -257,7 +257,7 @@ class MFCCLegacy:
         self.unsqueeze = Lambda(lambda_fn=lambda x: x.unsqueeze(0))
 
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.normalise(x)
+        x = self.normalise(x)
         x = python_speech_features.mfcc(
             x,
             samplerate=self.samplerate,

--- a/src/myrtlespeech/data/preprocess.py
+++ b/src/myrtlespeech/data/preprocess.py
@@ -230,9 +230,9 @@ class SpecAugment:
 class MFCCLegacy:
     """Legacy MFCC implementation using ``python_speech_features``.
 
-    This is required for backwards compatibility: **new users should not use
-    this class.** This class has the same API as
-    :py:class`torchaudio.transforms.MFCC`.
+    This is required for backwards compatibility with models trained on
+    features from ``python_speech_features.mfcc``. **New users should not use
+    this class.**
 
     Args:
         n_mfcc: Number of MFCC coefficients.

--- a/src/myrtlespeech/protos/pre_process_step.proto
+++ b/src/myrtlespeech/protos/pre_process_step.proto
@@ -19,7 +19,7 @@ message PreProcessStep {
 
 // Computes Mel-frequency cepstral coefficients (MFCC).
 message MFCC {
-  // Number of mfc coefficients to retain.
+  // Number of mfcc coefficients to retain.
   uint32 n_mfcc = 1;
 
   // Window size in number of frames.
@@ -27,6 +27,10 @@ message MFCC {
 
   // Step between successive windows in number of frames.
   uint32 hop_length = 3;
+
+  // If True, use legacy MFCC implementation. Required for backwards
+  // compatibility. Defaults to False.
+  bool legacy = 4;
 }
 
 

--- a/tests/protos/test_pre_process_step.py
+++ b/tests/protos/test_pre_process_step.py
@@ -66,6 +66,7 @@ def _mfccs(
     kwargs["n_mfcc"] = draw(st.integers(1, 128))
     kwargs["win_length"] = draw(st.integers(100, 400))
     kwargs["hop_length"] = draw(st.integers(50, kwargs["win_length"]))
+    kwargs["legacy"] = draw(st.booleans())
 
     # initialise and return
     all_fields_set(pre_process_step_pb2.MFCC, kwargs)


### PR DESCRIPTION
Small PR to add support for legacy MFCC (used in `deepspeech_internal`) to enable running of old weights in `myrtlespeech`. 